### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/tools/html-version/bounded-context-canvas-template.html
+++ b/tools/html-version/bounded-context-canvas-template.html
@@ -22,12 +22,12 @@
                     <div class="col border-right">
                         <div class="form-group">
                             <label for="name" class="font-weight-bolder">Name</label>
-                            <input tabindex="1" type="text" class="form-control" id="name" aria-describedby="nameHelp">
+                            <input type="text" class="form-control" id="name" aria-describedby="nameHelp">
                         </div>
                         <hr/>
                         <div class="form-group">
                             <label for="description" class="font-weight-bolder">Description</label>
-                            <textarea tabindex="2" class="form-control" id="description" rows="2" aria-describedby="description-help"></textarea>
+                            <textarea class="form-control" id="description" rows="2" aria-describedby="description-help"></textarea>
                             <small id="description-help" class="form-text text-muted">Summary of purpose and responsibilities</small>
                         </div>
                         <hr/>
@@ -35,7 +35,7 @@
                             <div class="col">
                                 <p class="font-weight-bolder text-center">BC Classification</p>
                                 <div class="form-check">
-                                    <input tabindex="3" class="form-check-input" type="radio" name="domain" id="domain-radios-1" value="core">
+                                    <input class="form-check-input" type="radio" name="domain" id="domain-radios-1" value="core">
                                     <label class="form-check-label" for="domain-radios-1">Core</label>
                                 </div>
                                 <div class="form-check">
@@ -50,7 +50,7 @@
                             <div class="col">
                                 <p class="font-weight-bolder text-center">Business Model</p>
                                 <div class="form-check">
-                                    <input tabindex="4" class="form-check-input" type="radio" name="business-model" id="business-model-radios-1" value="revenue">
+                                    <input class="form-check-input" type="radio" name="business-model" id="business-model-radios-1" value="revenue">
                                     <label class="form-check-label" for="business-model-radios-1">Revenue</label>
                                 </div>
                                 <div class="form-check">
@@ -69,7 +69,7 @@
                             <div class="col">
                                 <p class="font-weight-bolder text-center">Evolution</p>
                                 <div class="form-check">
-                                    <input tabindex="5" class="form-check-input" type="radio" name="evolution" id="evolution-radios-1" value="genesis">
+                                    <input class="form-check-input" type="radio" name="evolution" id="evolution-radios-1" value="genesis">
                                     <label class="form-check-label" for="evolution-radios-1">Genesis</label>
                                 </div>
                                 <div class="form-check">
@@ -89,7 +89,7 @@
                         
                         <div class="form-group">
                             <label for="model-traits" class="font-weight-bolder">Model traits</label>
-                            <input tabindex="8" type="text" class="form-control" id="model-traits" aria-describedby="model-traits-help">
+                            <input type="text" class="form-control" id="model-traits" aria-describedby="model-traits-help">
                             <small id="model-traits-help" class="form-text text-muted">draft, execute, audit, enforcer, interchange, gateway, etc.</small>
                         </div>
                     
@@ -105,27 +105,27 @@
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Collaborator</label>
-                                            <input tabindex="15" type="text" class="form-control" id="supplier-relationship-name-1">
-                                            <input tabindex="17" type="text" class="form-control" id="supplier-relationship-name-2">
-                                            <input tabindex="19" type="text" class="form-control" id="supplier-relationship-name-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Relationship</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-relationship-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-relationship-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-relationship-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Command</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-command-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-command-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-command-3">
+                                            <input type="text" class="form-control" id="supplier-command-1">
+                                            <input type="text" class="form-control" id="supplier-command-2">
+                                            <input type="text" class="form-control" id="supplier-command-3">
                                             
                                         </div>
                                     </div>
@@ -137,27 +137,27 @@
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Collaborator</label>
-                                            <input tabindex="15" type="text" class="form-control" id="supplier-relationship-name-1">
-                                            <input tabindex="17" type="text" class="form-control" id="supplier-relationship-name-2">
-                                            <input tabindex="19" type="text" class="form-control" id="supplier-relationship-name-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Relationship</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-relationship-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-relationship-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-relationship-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Event</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-event-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-event-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-event-3">
+                                            <input type="text" class="form-control" id="supplier-event-1">
+                                            <input type="text" class="form-control" id="supplier-event-2">
+                                            <input type="text" class="form-control" id="supplier-event-3">
                                             
                                         </div>
                                     </div>
@@ -168,27 +168,27 @@
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Collaborator</label>
-                                            <input tabindex="15" type="text" class="form-control" id="supplier-relationship-name-1">
-                                            <input tabindex="17" type="text" class="form-control" id="supplier-relationship-name-2">
-                                            <input tabindex="19" type="text" class="form-control" id="supplier-relationship-name-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Relationship</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-relationship-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-relationship-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-relationship-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Query</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-query-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-query-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-query-3">
+                                            <input type="text" class="form-control" id="supplier-query-1">
+                                            <input type="text" class="form-control" id="supplier-query-2">
+                                            <input type="text" class="form-control" id="supplier-query-3">
                                             
                                         </div>
                                     </div>
@@ -200,14 +200,12 @@
                     <div class="col border-right">  
                         <div class="form-group">
                             <label for="ubuquitous-language" class="font-weight-bolder">Ubiquitous Language</label>
-                            </p>
-                            <textarea tabindex="7" class="form-control" id="ubuquitous-language" rows="5" aria-describedby="ubiquitous-language-help"></textarea>
+                            <textarea class="form-control" id="ubuquitous-language" rows="5" aria-describedby="ubiquitous-language-help"></textarea>
                             <small id="ubiquitous-language-help" class="form-text text-muted">Key domain terminology</small>
                         </div>
                         <div class="form-group">
                             <label for="business-decisions" class="font-weight-bolder">Business Decisions</label>
-                            </p>  
-                            <textarea tabindex="6" class="form-control" id="business-decisions" rows="5" aria-describedby="business-decisions-help"></textarea>
+                            <textarea class="form-control" id="business-decisions" rows="5" aria-describedby="business-decisions-help"></textarea>
                             <small id="business-decisions-help" class="form-text text-muted">Key business rules, policies and decisions</small>
                         </div>
                         <hr/>                        
@@ -221,27 +219,27 @@
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Command</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-command-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-command-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-command-3">
+                                            <input type="text" class="form-control" id="supplier-command-1">
+                                            <input type="text" class="form-control" id="supplier-command-2">
+                                            <input type="text" class="form-control" id="supplier-command-3">
                                             
                                         </div>
                                     </div>                                    
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Relationship</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-relationship-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-relationship-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-relationship-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Collaborator</label>
-                                            <input tabindex="15" type="text" class="form-control" id="supplier-relationship-name-1">
-                                            <input tabindex="17" type="text" class="form-control" id="supplier-relationship-name-2">
-                                            <input tabindex="19" type="text" class="form-control" id="supplier-relationship-name-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-3">
                                             
                                         </div>
                                     </div>
@@ -253,27 +251,27 @@
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Event</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-event-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-event-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-event-3">
+                                            <input type="text" class="form-control" id="supplier-event-1">
+                                            <input type="text" class="form-control" id="supplier-event-2">
+                                            <input type="text" class="form-control" id="supplier-event-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Relationship</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-relationship-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-relationship-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-relationship-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Collaborator</label>
-                                            <input tabindex="15" type="text" class="form-control" id="supplier-relationship-name-1">
-                                            <input tabindex="17" type="text" class="form-control" id="supplier-relationship-name-2">
-                                            <input tabindex="19" type="text" class="form-control" id="supplier-relationship-name-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-3">
                                             
                                         </div>
                                     </div>
@@ -284,27 +282,27 @@
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Query</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-query-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-query-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-query-3">
+                                            <input type="text" class="form-control" id="supplier-query-1">
+                                            <input type="text" class="form-control" id="supplier-query-2">
+                                            <input type="text" class="form-control" id="supplier-query-3">
                                             
                                         </div>
                                     </div>
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Relationship</label>
-                                            <input tabindex="16" type="text" class="form-control" id="supplier-relationship-1">
-                                            <input tabindex="18" type="text" class="form-control" id="supplier-relationship-2">
-                                            <input tabindex="20" type="text" class="form-control" id="supplier-relationship-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-3">
                                             
                                         </div>
                                     </div>                                    
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Collaborator</label>
-                                            <input tabindex="15" type="text" class="form-control" id="supplier-relationship-name-1">
-                                            <input tabindex="17" type="text" class="form-control" id="supplier-relationship-name-2">
-                                            <input tabindex="19" type="text" class="form-control" id="supplier-relationship-name-3">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-1">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-2">
+                                            <input type="text" class="form-control" id="supplier-relationship-name-3">
                                             
                                         </div>
                                     </div>
@@ -321,7 +319,7 @@
             <small id="relationships-help" class="form-text text-muted">ACL: Anti-Corruption Layer - OHS: Open Host Service - PL: Published Language</small>
             <article>
                 <section>
-                    <p>Source and Documentation<a tabindex="35" href="https://github.com/ddd-crew/bounded-context-canvas" target="-blank" rel="noopener noreferrer">DDD Crew on GitHub: Bounded Context Canvas</a></p>
+                    <p>Source and Documentation<a href="https://github.com/ddd-crew/bounded-context-canvas" target="-blank" rel="noopener noreferrer">DDD Crew on GitHub: Bounded Context Canvas</a></p>
                     
                 </section>
             </article>


### PR DESCRIPTION
Removed explicit tabindexes to let the browser defaults kick in, which are usually best optional accessibility wise, as the HTML form element content ordering is logical.

I made some assumptions here, else while I was using the template via keyboard only, tabbing from field to field, in particular Inbound Communication, Outbound Communication areas, the tabbing would jump to very unexpected areas.

There's probably a lot more nice things we can do, e.g. each of the text fields without labels could be given some visually hidden ones for those using assistive technologies, or enhance this with a small bit of JavaScript to add more rows etc etc. But left that out for now :-)