### PR TITLE
Turned HTML version into self-saving document

### DIFF
--- a/tools/html-version/README.md
+++ b/tools/html-version/README.md
@@ -4,25 +4,10 @@ The *bounded context canvas* is described in [this blog post](https://medium.com
 
 ## Prerequisites
 
-Install the **Save Page WE** add-on/extension
-
-- [Firefox](https://addons.mozilla.org/en-US/firefox/addon/save-page-we/)
-- [Chrome](https://chrome.google.com/webstore/detail/save-page-we/dhhpefjklgkmgeafimnjhojgjamoafof)
-
-It allows you to save the current page (static html + data filled in) as an html file (which can live next to the bounded context's code).
-
-Doing so allows one to re-open the saved html file and update the filled in data.
-
-### Note for Chrome users
-
-Once the extension is intalled, Chrome users need to do the following:
-
-1. right clic on the extension's icon
-1. "Manage extensions"
-1. check "Allow access to file URLs"
+You need a moderately modern browser for saving changes.
 
 ## How to
 
 - Either continue from a canvas you already started or start from the `bounded-context-canvas-template.html`.
 - Fill it in with your team.
-- Save the current page by clicking on the add-on/extension's icon and save it near the bounded context's code.
+- Save the current page by clicking on the download link and save it near the bounded context's code.

--- a/tools/html-version/bounded-context-canvas-template.html
+++ b/tools/html-version/bounded-context-canvas-template.html
@@ -9,6 +9,12 @@
             @page {
                 size: auto
             }
+
+            #download-link {
+                position: fixed;
+                top: 0.5rem;
+                right: 0.5rem;
+            }
         </style>
         <title>Bounded Context Canvas</title>
     </head>
@@ -352,8 +358,9 @@
             </article>
         </footer>
 
+        <a id="download-link" class="btn btn-primary btn-lg" download="bounded-context-canvas.html" hidden>download</a>
         <script type="module">
-let downloadLink;
+let downloadLink = document.getElementById("download-link");
 
 document.body.addEventListener("change", ev => {
     // synchronize form elements' properties with corresponding HTML state
@@ -389,28 +396,19 @@ document.body.addEventListener("change", ev => {
     }
 
     // generate download link
-    if(downloadLink) {
-        downloadLink.remove();
-    }
-    let html = serializeDOM();
-    downloadLink = generateDownloadLink("bounded-context-canvas.html", html);
-    downloadLink.textContent = "download";
-    document.body.appendChild(downloadLink);
+    let uri = generateDownloadURI(serializeDOM());
+    downloadLink.setAttribute("href", uri);
+    downloadLink.hidden = false;
 });
 
 // adapted from TiddlyWiki <http://tiddlywiki.com>
-function generateDownloadLink(filename, html) {
+function generateDownloadURI(html) {
     try {
         let blob = new Blob([html], { type: "text/html" });
-        var uri = URL.createObjectURL(blob);
+        return URL.createObjectURL(blob);
     } catch(err) { // XXX: obsolete?
-        uri = `data:text/html,${encodeURIComponent(html)}`;
+        return `data:text/html,${encodeURIComponent(html)}`;
     }
-
-    let el = document.createElement("a");
-    el.setAttribute("download", filename);
-    el.setAttribute("href", uri);
-    return el;
 }
 
 function serializeDOM(doctype = document.doctype,

--- a/tools/html-version/bounded-context-canvas-template.html
+++ b/tools/html-version/bounded-context-canvas-template.html
@@ -398,6 +398,9 @@ document.body.addEventListener("change", ev => {
     // generate download link
     downloadLink.hidden = true;
     downloadLink.removeAttribute("href");
+    if(el.id === "name") { // use canvas name as file name
+        downloadLink.setAttribute("download", `${slugify(el.value)}.html`);
+    }
     let html = serializeDOM();
     let uri = generateDownloadURI(html);
     downloadLink.href = uri;
@@ -418,6 +421,12 @@ function serializeDOM(doctype = document.doctype,
         documentElement = document.documentElement) {
     doctype = new XMLSerializer().serializeToString(doctype);
     return [doctype, documentElement.outerHTML].join("\n");
+}
+
+function slugify(str) {
+    return str.toLowerCase().
+        replace(/[^0-9a-z-]+/g, "_").
+        replace(/^_|_$/g, "");
 }
         </script>
     </body>

--- a/tools/html-version/bounded-context-canvas-template.html
+++ b/tools/html-version/bounded-context-canvas-template.html
@@ -396,8 +396,11 @@ document.body.addEventListener("change", ev => {
     }
 
     // generate download link
-    let uri = generateDownloadURI(serializeDOM());
-    downloadLink.setAttribute("href", uri);
+    downloadLink.hidden = true;
+    downloadLink.removeAttribute("href");
+    let html = serializeDOM();
+    let uri = generateDownloadURI(html);
+    downloadLink.href = uri;
     downloadLink.hidden = false;
 });
 

--- a/tools/html-version/bounded-context-canvas-template.html
+++ b/tools/html-version/bounded-context-canvas-template.html
@@ -348,11 +348,11 @@
             </form>
         </main>
         <footer>
-            <small id="dependenciesHelp" class="form-text text-muted">Relationship : mutually dependant, upstream/downstream, indepedant</small>
+            <small id="dependenciesHelp" class="form-text text-muted">Relationships: mutually dependent, upstream/downstream, independent</small>
             <small id="relationships-help" class="form-text text-muted">ACL: Anti-Corruption Layer - OHS: Open Host Service - PL: Published Language</small>
             <article>
                 <section>
-                    <p>Source and Documentation<a href="https://github.com/ddd-crew/bounded-context-canvas" target="-blank" rel="noopener noreferrer">DDD Crew on GitHub: Bounded Context Canvas</a></p>
+                    <p>Source and Documentation: <a href="https://github.com/ddd-crew/bounded-context-canvas" target="_blank" rel="noopener noreferrer">DDD Crew on GitHub: Bounded Context Canvas</a></p>
                     
                 </section>
             </article>

--- a/tools/html-version/bounded-context-canvas-template.html
+++ b/tools/html-version/bounded-context-canvas-template.html
@@ -351,5 +351,73 @@
                 </section>
             </article>
         </footer>
+
+        <script type="module">
+let downloadLink;
+
+document.body.addEventListener("change", ev => {
+    // synchronize form elements' properties with corresponding HTML state
+    let el = ev.target;
+    let tag = el.localName;
+    switch(tag) {
+    case "input":
+        switch(el.type) {
+        case "text":
+            el.setAttribute("value", el.value);
+            break;
+        case "radio":
+            let nodes = document.querySelectorAll(`input[type=radio][name=${el.name}`);
+            for(let node of nodes) {
+                if(node === el) {
+                    node.setAttribute("checked", "");
+                } else {
+                    node.removeAttribute("checked");
+                }
+            }
+            break;
+        default:
+            console.error(`WARNING: unsupported element \`${tag}\``);
+            break;
+        }
+        break;
+    case "textarea":
+        el.textContent = el.value;
+        break;
+    default:
+        console.error(`WARNING: unsupported element \`${tag}\``);
+        break;
+    }
+
+    // generate download link
+    if(downloadLink) {
+        downloadLink.remove();
+    }
+    let html = serializeDOM();
+    downloadLink = generateDownloadLink("bounded-context-canvas.html", html);
+    downloadLink.textContent = "download";
+    document.body.appendChild(downloadLink);
+});
+
+// adapted from TiddlyWiki <http://tiddlywiki.com>
+function generateDownloadLink(filename, html) {
+    try {
+        let blob = new Blob([html], { type: "text/html" });
+        var uri = URL.createObjectURL(blob);
+    } catch(err) { // XXX: obsolete?
+        uri = `data:text/html,${encodeURIComponent(html)}`;
+    }
+
+    let el = document.createElement("a");
+    el.setAttribute("download", filename);
+    el.setAttribute("href", uri);
+    return el;
+}
+
+function serializeDOM(doctype = document.doctype,
+        documentElement = document.documentElement) {
+    doctype = new XMLSerializer().serializeToString(doctype);
+    return [doctype, documentElement.outerHTML].join("\n");
+}
+        </script>
     </body>
 </html>


### PR DESCRIPTION
as suggested in #33 

> this is fairly crude, particulary because for now we only support text fields (both `input[type=text]` and `textarea`) and radio buttons
>
> we might also use file-system APIs <https://web.dev/file-system-access/> where supported, but that seems overkill for the moment

NB: This has _not_ been heavily tested, so a thorough review seems necessary.